### PR TITLE
feat: Use javascript_tag helper for vite_react_refresh_tag

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -59,6 +59,10 @@ end
 class HelperTest < HelperTestCase
   tests ViteRails::TagHelpers
 
+  def content_security_policy_nonce
+    'iyhD0Yc0W+c='
+  end
+
   def test_vite_client_tag
     assert_nil vite_client_tag
     with_dev_server_running {
@@ -130,13 +134,33 @@ class HelperTest < HelperTestCase
   def test_vite_react_refresh_tag
     assert_nil vite_react_refresh_tag
     with_dev_server_running {
-      assert_equal <<~HTML, vite_react_refresh_tag
+      assert_equal <<~HTML.chomp, vite_react_refresh_tag
         <script type="module">
-          import RefreshRuntime from '/vite-dev/@react-refresh'
-          RefreshRuntime.injectIntoGlobalHook(window)
-          window.$RefreshReg$ = () => {}
-          window.$RefreshSig$ = () => (type) => type
-          window.__vite_plugin_react_preamble_installed__ = true
+        //<![CDATA[
+        import RefreshRuntime from '/vite-dev/@react-refresh'
+        RefreshRuntime.injectIntoGlobalHook(window)
+        window.$RefreshReg$ = () => {}
+        window.$RefreshSig$ = () => (type) => type
+        window.__vite_plugin_react_preamble_installed__ = true
+
+        //]]>
+        </script>
+      HTML
+    }
+  end
+
+  def test_vite_react_refresh_tag_with_nonce
+    with_dev_server_running {
+      assert_equal <<~HTML.chomp, vite_react_refresh_tag(nonce: true)
+        <script type="module" nonce="#{ content_security_policy_nonce }">
+        //<![CDATA[
+        import RefreshRuntime from '/vite-dev/@react-refresh'
+        RefreshRuntime.injectIntoGlobalHook(window)
+        window.$RefreshReg$ = () => {}
+        window.$RefreshSig$ = () => (type) => type
+        window.__vite_plugin_react_preamble_installed__ = true
+
+        //]]>
         </script>
       HTML
     }

--- a/vite_rails/lib/vite_rails/tag_helpers.rb
+++ b/vite_rails/lib/vite_rails/tag_helpers.rb
@@ -10,8 +10,10 @@ module ViteRails::TagHelpers
   end
 
   # Public: Renders a script tag to enable HMR with React Refresh.
-  def vite_react_refresh_tag
-    vite_manifest.react_refresh_preamble&.html_safe
+  def vite_react_refresh_tag(**options)
+    return unless react_preamble_code = vite_manifest.react_preamble_code
+
+    javascript_tag(react_preamble_code&.html_safe, type: :module, **options)
   end
 
   # Public: Resolves the path for the specified Vite asset.

--- a/vite_ruby/lib/vite_ruby/manifest.rb
+++ b/vite_ruby/lib/vite_ruby/manifest.rb
@@ -51,13 +51,22 @@ class ViteRuby::Manifest
     if dev_server_running?
       <<~REACT_REFRESH
         <script type="module">
-          import RefreshRuntime from '#{ prefix_asset_with_host('@react-refresh') }'
-          RefreshRuntime.injectIntoGlobalHook(window)
-          window.$RefreshReg$ = () => {}
-          window.$RefreshSig$ = () => (type) => type
-          window.__vite_plugin_react_preamble_installed__ = true
+          #{ react_preamble_code }
         </script>
       REACT_REFRESH
+    end
+  end
+
+  # Public: Source script for the React Refresh plugin.
+  def react_preamble_code
+    if dev_server_running?
+      <<~REACT_PREAMBLE_CODE
+        import RefreshRuntime from '#{ prefix_asset_with_host('@react-refresh') }'
+        RefreshRuntime.injectIntoGlobalHook(window)
+        window.$RefreshReg$ = () => {}
+        window.$RefreshSig$ = () => (type) => type
+        window.__vite_plugin_react_preamble_installed__ = true
+      REACT_PREAMBLE_CODE
     end
   end
 


### PR DESCRIPTION
feat: Use javascript_tag helper for vite_react_refresh_tag allowing h…tml_options

### Description 📖

This pull request updated the `vite_react_refresh_tag` method to use the Rails JavaScript helper method [`javascript_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/JavaScriptHelper.html#method-i-javascript_tag) in order to support HTML options.

### Background 📜

This was happening because of #249. When adding Content Security Policy on a Rails project with something other than `unsafe-inline` the inline JS for the react refresh script was not being allowed.

### The Fix 🔨

By changing the `vite_react_refresh_tag` to use Rails' `javascript_tag` we can now add HTML options such as `nonce: true`.

The code adds the method `react_preamble_code` which has the script for the React Refresh plugin.

The `react_refresh_preamble` is left unchanged with the exception of using the `react_preamble_code` method internally inside its `<script>...</script>` tags.

### Screenshots 📷
